### PR TITLE
Add an `allocate` function to `FileIoExt`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.5.1"
+posish = "0.5.2"
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ posish = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"
-cap-std = { version = "0.5.0", optional = true }
+cap-std = { version = "0.6.0", optional = true }
 winapi = { version = "0.3.9", features = [
     "winerror",
     "winsock2",
 ] }
-winx = "0.20.0"
+winx = "0.21.0"
 
 [dev-dependencies]
-cap-tempfile = "0.5.0"
-cap-std = "0.5.0"
+cap-tempfile = "0.6.0"
+cap-std = "0.6.0"
 tempfile = "3.1.0"
 atty = "0.2.14"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.5.0"
+posish = "0.5.1"
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.4.1"
+posish = "0.5.0"
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -4,9 +4,11 @@ use super::{as_file, into_file};
     target_os = "ios",
     target_os = "macos",
     target_os = "netbsd",
-    target_os = "redox"
+    target_os = "redox",
 )))]
 use posish::fs::fadvise;
+#[cfg(not(any(windows, target_os = "netbsd", target_os = "redox")))]
+use posish::fs::posix_fallocate;
 #[cfg(any(target_os = "ios", target_os = "macos"))]
 use posish::fs::rdadvise;
 #[cfg(not(windows))]
@@ -86,6 +88,10 @@ pub enum Advice {
 pub trait FileIoExt {
     /// Announce the expected access pattern of the data at the given offset.
     fn advise(&self, offset: u64, len: u64, advice: Advice) -> io::Result<()>;
+
+    /// Allocate space in the file, increasing the file size as needed, and
+    /// ensuring that there are no holes under the given range.
+    fn allocate(&self, offset: u64, len: u64) -> io::Result<()>;
 
     /// Pull some bytes from this source into the specified buffer, returning
     /// how many bytes were read.
@@ -460,6 +466,22 @@ where
         Ok(())
     }
 
+    #[cfg(not(any(target_os = "netbsd", target_os = "redox")))]
+    #[inline]
+    fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
+        posix_fallocate(self, offset, len)
+    }
+
+    #[cfg(target_os = "netbsd")]
+    fn allocate(&self, _offset: u64, _len: u64) -> io::Result<()> {
+        todo!("NetBSD 7.0 supports posix_fallocate; add bindings for it")
+    }
+
+    #[cfg(target_os = "redox")]
+    fn allocate(&self, _offset: u64, _len: u64) -> io::Result<()> {
+        todo!("figure out what to do on redox for posix_fallocate")
+    }
+
     #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         Read::read(&mut *unsafe { as_file(self) }, buf)
@@ -588,6 +610,17 @@ impl FileIoExt for fs::File {
     fn advise(&self, _offset: u64, _len: u64, _advice: Advice) -> io::Result<()> {
         // TODO: Do something with the advice.
         Ok(())
+    }
+
+    #[inline]
+    fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
+        // In theory we could do a `reopen` + `seek` first, allowing the OS to
+        // create a sparse file, but Windows doesn't guarantee to zero-fill.
+        // The following doesn't guarantee to make the file dense in the
+        // given range, but Windows doesn't have a simple way to do that either.
+        self.set_len(offset.checked_add(len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "overflow while allocating file space")
+        })?)
     }
 
     #[inline]

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -838,6 +838,17 @@ impl FileIoExt for cap_std::fs::File {
     }
 
     #[inline]
+    fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
+        // In theory we could do a `reopen` + `seek` first, allowing the OS to
+        // create a sparse file, but Windows doesn't guarantee to zero-fill.
+        // The following doesn't guarantee to make the file dense in the
+        // given range, but Windows doesn't have a simple way to do that either.
+        self.set_len(offset.checked_add(len).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::Other, "overflow while allocating file space")
+        })?)
+    }
+
+    #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
         Read::read(&mut *unsafe { as_file(self) }, buf)
     }

--- a/src/io/is_terminal.rs
+++ b/src/io/is_terminal.rs
@@ -1,6 +1,5 @@
 #[cfg(not(windows))]
 use posish::io::isatty;
-use std::io;
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
 #[cfg(target_os = "wasi")]
@@ -17,7 +16,7 @@ pub trait IsTerminal {
     /// Test whether this output stream is attached to a terminal.
     ///
     /// This operation is also known as `isatty`.
-    fn is_terminal(&self) -> io::Result<bool>;
+    fn is_terminal(&self) -> bool;
 }
 
 /// Implement `IsTerminal` for types that implement `AsRawFd`.
@@ -27,7 +26,7 @@ where
     T: AsRawFd,
 {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
+    fn is_terminal(&self) -> bool {
         isatty(self)
     }
 }
@@ -36,8 +35,8 @@ where
 #[cfg(windows)]
 impl IsTerminal for Stdin {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(atty::is(atty::Stream::Stdin))
+    fn is_terminal(&self) -> bool {
+        atty::is(atty::Stream::Stdin)
     }
 }
 
@@ -45,8 +44,8 @@ impl IsTerminal for Stdin {
 #[cfg(windows)]
 impl<'a> IsTerminal for StdinLock<'a> {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(atty::is(atty::Stream::Stdin))
+    fn is_terminal(&self) -> bool {
+        atty::is(atty::Stream::Stdin)
     }
 }
 
@@ -54,8 +53,8 @@ impl<'a> IsTerminal for StdinLock<'a> {
 #[cfg(windows)]
 impl IsTerminal for Stdout {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(atty::is(atty::Stream::Stdout))
+    fn is_terminal(&self) -> bool {
+        atty::is(atty::Stream::Stdout)
     }
 }
 
@@ -63,8 +62,8 @@ impl IsTerminal for Stdout {
 #[cfg(windows)]
 impl<'a> IsTerminal for StdoutLock<'a> {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(atty::is(atty::Stream::Stdout))
+    fn is_terminal(&self) -> bool {
+        atty::is(atty::Stream::Stdout)
     }
 }
 
@@ -72,8 +71,8 @@ impl<'a> IsTerminal for StdoutLock<'a> {
 #[cfg(windows)]
 impl IsTerminal for Stderr {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(atty::is(atty::Stream::Stderr))
+    fn is_terminal(&self) -> bool {
+        atty::is(atty::Stream::Stderr)
     }
 }
 
@@ -81,8 +80,8 @@ impl IsTerminal for Stderr {
 #[cfg(windows)]
 impl<'a> IsTerminal for StderrLock<'a> {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(atty::is(atty::Stream::Stderr))
+    fn is_terminal(&self) -> bool {
+        atty::is(atty::Stream::Stderr)
     }
 }
 
@@ -90,8 +89,8 @@ impl<'a> IsTerminal for StderrLock<'a> {
 #[cfg(windows)]
 impl<'a> IsTerminal for fs::File {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(false)
+    fn is_terminal(&self) -> bool {
+        false
     }
 }
 
@@ -99,8 +98,8 @@ impl<'a> IsTerminal for fs::File {
 #[cfg(windows)]
 impl<'a> IsTerminal for net::TcpStream {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(false)
+    fn is_terminal(&self) -> bool {
+        false
     }
 }
 
@@ -108,8 +107,8 @@ impl<'a> IsTerminal for net::TcpStream {
 #[cfg(all(windows, feature = "cap_std_impls"))]
 impl<'a> IsTerminal for cap_std::fs::File {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(false)
+    fn is_terminal(&self) -> bool {
+        false
     }
 }
 
@@ -117,7 +116,7 @@ impl<'a> IsTerminal for cap_std::fs::File {
 #[cfg(all(windows, feature = "cap_std_impls"))]
 impl<'a> IsTerminal for cap_std::net::TcpStream {
     #[inline]
-    fn is_terminal(&self) -> io::Result<bool> {
-        Ok(false)
+    fn is_terminal(&self) -> bool {
+        false
     }
 }

--- a/tests/allocate.rs
+++ b/tests/allocate.rs
@@ -1,0 +1,29 @@
+#[macro_use]
+mod sys_common;
+
+use std::fs::OpenOptions;
+use system_interface::fs::FileIoExt;
+
+#[test]
+fn allocate() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = check!(OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(dir.path().join("file")));
+
+    assert_eq!(check!(file.metadata()).len(), 0);
+
+    check!(file.allocate(1024, 1024));
+
+    assert_eq!(check!(file.metadata()).len(), 1024 + 1024);
+
+    check!(file.allocate(1024, 1024));
+
+    assert_eq!(check!(file.metadata()).len(), 1024 + 1024);
+
+    check!(file.allocate(4096, 4096));
+
+    assert_eq!(check!(file.metadata()).len(), 4096 + 4096);
+}

--- a/tests/is_terminal.rs
+++ b/tests/is_terminal.rs
@@ -10,27 +10,24 @@ use system_interface::io::IsTerminal;
 fn cap_std_file_is_not_terminal() {
     let tmpdir = tmpdir();
     check!(tmpdir.create("file"));
-    assert!(!check!(check!(tmpdir.open("file")).is_terminal()));
+    assert!(!check!(tmpdir.open("file")).is_terminal());
 }
 
 #[test]
 fn std_file_is_not_terminal() {
     let tmpdir = tempfile::tempdir().unwrap();
     check!(std::fs::File::create(tmpdir.path().join("file")));
-    assert!(!check!(check!(std::fs::File::open(
-        tmpdir.path().join("file")
-    ))
-    .is_terminal()));
+    assert!(!check!(std::fs::File::open(tmpdir.path().join("file"))).is_terminal());
 }
 
 #[test]
 fn stdout_stderr_terminals() {
     assert_eq!(
-        check!(std::io::stdout().is_terminal()),
+        std::io::stdout().is_terminal(),
         atty::is(atty::Stream::Stdout)
     );
     assert_eq!(
-        check!(std::io::stderr().is_terminal()),
+        std::io::stderr().is_terminal(),
         atty::is(atty::Stream::Stderr)
     );
 }


### PR DESCRIPTION
Update to posish 0.6.0 and add an `allocate` function to `FileIoExt` using `posix_fallocate` where available.