### PR TITLE
FileIoExt: remove `bytes` and `take` methods

### DIFF
--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -1,4 +1,4 @@
-use super::{as_file, into_file};
+use super::as_file;
 #[cfg(not(any(
     windows,
     target_os = "ios",
@@ -22,7 +22,6 @@ use std::os::wasi::{fs::FileExt, io::AsRawFd};
 use std::{
     convert::TryInto,
     fmt::Arguments,
-    fs,
     io::{self, IoSlice, IoSliceMut, Read, Seek, SeekFrom, Write},
     slice,
 };

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -203,23 +203,6 @@ pub trait FileIoExt {
     /// [`std::io::Read::read_to_string`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_to_string
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize>;
 
-    /// Transforms this `FileIoExt` instance to an [`Iterator`] over its bytes.
-    ///
-    /// This is similar to [`Read::bytes`], except it returns a
-    /// `io::Bytes<fs::File>` instead of an `io::Bytes::<Self>`.
-    ///
-    /// [`Iterator`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html
-    /// [`Read::bytes`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.bytes
-    fn bytes(self) -> io::Bytes<fs::File>;
-
-    /// Creates an adaptor which will read at most `limit` bytes from it.
-    ///
-    /// This is similar to [`Read::take`], except it returns a
-    /// `io::Take<fs::File>` instead of an `io::Take::<Self>`.
-    ///
-    /// [`Read::take`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.take
-    fn take(self, limit: u64) -> io::Take<fs::File>;
-
     /// Write a buffer into this writer, returning how many bytes were written.
     ///
     /// This is similar to [`std::io::Write::write`], except it takes `self` by
@@ -522,16 +505,6 @@ where
     }
 
     #[inline]
-    fn bytes(self) -> io::Bytes<fs::File> where {
-        Read::bytes(into_file(self))
-    }
-
-    #[inline]
-    fn take(self, limit: u64) -> io::Take<fs::File> where {
-        Read::take(into_file(self), limit)
-    }
-
-    #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
         Write::write(&mut *unsafe { as_file(self) }, buf)
     }
@@ -697,16 +670,6 @@ impl FileIoExt for fs::File {
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
         Read::read_to_string(&mut *unsafe { as_file(self) }, buf)
-    }
-
-    #[inline]
-    fn bytes(self) -> io::Bytes<fs::File> where {
-        Read::bytes(into_file(self))
-    }
-
-    #[inline]
-    fn take(self, limit: u64) -> io::Take<fs::File> where {
-        Read::take(into_file(self), limit)
     }
 
     #[inline]
@@ -917,16 +880,6 @@ impl FileIoExt for cap_std::fs::File {
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
         Read::read_to_string(&mut *unsafe { as_file(self) }, buf)
-    }
-
-    #[inline]
-    fn bytes(self) -> io::Bytes<fs::File> where {
-        Read::bytes(into_file(self))
-    }
-
-    #[inline]
-    fn take(self, limit: u64) -> io::Take<fs::File> where {
-        Read::take(into_file(self), limit)
     }
 
     #[inline]

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -28,7 +28,7 @@ use std::{
 #[cfg(windows)]
 use {
     std::fs,
-    std::os::windows::io::{AsRawHandle, RawHandle},
+    std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle},
     winx::file::{reopen_file, AccessMode, Flags},
 };
 

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -27,10 +27,8 @@ use std::{
 };
 #[cfg(windows)]
 use {
-    std::os::windows::{
-        fs::FileExt,
-        io::{AsRawHandle, FromRawHandle, RawHandle},
-    },
+    std::fs,
+    std::os::windows::io::{AsRawHandle, RawHandle},
     winx::file::{reopen_file, AccessMode, Flags},
 };
 

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -28,6 +28,7 @@ use std::{
 #[cfg(windows)]
 use {
     std::fs,
+    std::os::windows::fs::FileExt,
     std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle},
     winx::file::{reopen_file, AccessMode, Flags},
 };

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -30,16 +30,6 @@ pub(crate) unsafe fn as_file(file: &impl AsRawHandle) -> std::mem::ManuallyDrop<
     std::mem::ManuallyDrop::new(std::fs::File::from_raw_handle(file.as_raw_handle()))
 }
 
-#[cfg(not(windows))]
-pub(crate) fn into_file<Fd: AsRawFd>(file: Fd) -> std::fs::File {
-    unsafe { std::fs::File::from_raw_fd(file.as_raw_fd()) }
-}
-
-#[cfg(windows)]
-pub(crate) fn into_file<Handle: AsRawHandle>(file: Handle) -> std::fs::File {
-    unsafe { std::fs::File::from_raw_handle(file.as_raw_handle()) }
-}
-
 impl crate::io::ReadReady for std::fs::File {
     #[inline]
     fn num_ready_bytes(&self) -> std::io::Result<u64> {


### PR DESCRIPTION
these methods return generic structs which are parameterized to a
concrete `std::fs::File`. For any implementation of this trait thats not
backed by a File, this may be impossible to satisify.