### PR TITLE
Add Peek and implement ReadReady and Peek for more types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ atty = "0.2.14"
 [features]
 default = []
 cap_std_impls = ["cap-std"]
+cap_std_impls_fs_utf8 = ["cap-std/fs_utf8"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
+os_pipe = { version = "0.9.2", optional = true }
+socketpair = { version = "0.3.1", optional = true }
+char-device = { version = "0.0.0", optional = true }
 unsafe-io = "0.2.0"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-unsafe-io = "0.1.0"
+unsafe-io = "0.2.0"
 
 [target.'cfg(not(windows))'.dependencies]
 posish = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/bytecodealliance/system-interface"
 edition = "2018"
 readme = "README.md"
 
+[build-dependencies]
+rustc_version = "0.3.0"
+
 [dependencies]
 os_pipe = { version = "0.9.2", optional = true }
 socketpair = { version = "0.3.1", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,30 @@
+fn main() {
+    if let rustc_version::Channel::Nightly = rustc_version::version_meta()
+        .expect("query rustc release channel")
+        .channel
+    {
+        for feature in &[
+            "can_vector",         // https://github.com/rust-lang/rust/issues/69941
+            "read_initializer",   // https://github.com/rust-lang/rust/issues/42788
+            "seek_convenience",   // https://github.com/rust-lang/rust/issues/59359
+            "with_options",       // https://github.com/rust-lang/rust/issues/65439
+            "write_all_vectored", // https://github.com/rust-lang/rust/issues/70436
+            "windows_by_handle",  // https://github.com/rust-lang/rust/issues/63010
+            "windows_file_type_ext",
+            "open_options_ext_as_flags", // https://github.com/rust-lang/rust/issues/76801
+            "try_reserve",               // https://github.com/rust-lang/rust/issues/56431
+            "shrink_to",                 // https://github.com/rust-lang/rust/issues/56431
+            "pattern",                   // https://github.com/rust-lang/rust/issues/27721
+            "clamp",                     // https://github.com/rust-lang/rust/issues/44095
+            "extend_one",                // https://github.com/rust-lang/rust/issues/72631
+            "toowned_clone_into",        // https://github.com/rust-lang/rust/issues/41263
+            "unix_socket_peek",          // https://github.com/rust-lang/rust/issues/76923
+        ] {
+            println!("cargo:rustc-cfg={}", feature);
+        }
+    }
+
+    // Don't rerun this on changes other than build.rs, as we only depend on
+    // the rustc version.
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -916,6 +916,134 @@ impl FileIoExt for cap_std::fs::File {
     }
 }
 
+#[cfg(all(windows, feature = "cap_std_impls_fs_utf8"))]
+impl FileIoExt for cap_std::fs_utf8::File {
+    #[inline]
+    fn advise(&self, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
+        self.as_file_view().advise(offset, len, advice)
+    }
+
+    #[inline]
+    fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
+        self.as_file_view().allocate(offset, len)
+    }
+
+    #[inline]
+    fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.as_file_view().read(buf)
+    }
+
+    #[inline]
+    fn read_exact(&self, buf: &mut [u8]) -> io::Result<()> {
+        self.as_file_view().read_exact(buf)
+    }
+
+    #[inline]
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        self.as_file_view().read_at(buf, offset)
+    }
+
+    #[inline]
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
+        self.as_file_view().read_exact_at(buf, offset)
+    }
+
+    #[inline]
+    fn read_vectored(&self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
+        self.as_file_view().read_vectored(bufs)
+    }
+
+    #[inline]
+    fn read_vectored_at(&self, bufs: &mut [IoSliceMut], offset: u64) -> io::Result<usize> {
+        self.as_file_view().read_vectored_at(bufs, offset)
+    }
+
+    #[inline]
+    fn read_exact_vectored_at(&self, bufs: &mut [IoSliceMut], offset: u64) -> io::Result<()> {
+        self.as_file_view().read_exact_vectored_at(bufs, offset)
+    }
+
+    #[inline]
+    fn is_read_vectored_at(&self) -> bool {
+        self.as_file_view().is_read_vectored_at()
+    }
+
+    #[inline]
+    fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.as_file_view().read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
+        self.as_file_view().read_to_string(buf)
+    }
+
+    #[inline]
+    fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.as_file_view().peek(buf)
+    }
+
+    #[inline]
+    fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        self.as_file_view().write(buf)
+    }
+
+    #[inline]
+    fn write_all(&self, buf: &[u8]) -> io::Result<()> {
+        self.as_file_view().write_all(buf)
+    }
+
+    #[inline]
+    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
+        self.as_file_view().write_at(buf, offset)
+    }
+
+    #[inline]
+    fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
+        self.as_file_view().write_all_at(buf, offset)
+    }
+
+    #[inline]
+    fn write_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
+        self.as_file_view().write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_vectored_at(&self, bufs: &[IoSlice], offset: u64) -> io::Result<usize> {
+        self.as_file_view().write_vectored_at(bufs, offset)
+    }
+
+    #[inline]
+    fn write_all_vectored_at(&self, bufs: &mut [IoSlice], offset: u64) -> io::Result<()> {
+        self.as_file_view().write_all_vectored_at(bufs, offset)
+    }
+
+    #[inline]
+    fn is_write_vectored_at(&self) -> bool {
+        self.as_file_view().is_write_vectored_at()
+    }
+
+    #[inline]
+    fn flush(&self) -> io::Result<()> {
+        self.as_file_view().flush()
+    }
+
+    #[inline]
+    fn write_fmt(&self, fmt: Arguments) -> io::Result<()> {
+        self.as_file_view().write_fmt(fmt)
+    }
+
+    #[inline]
+    fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
+        self.as_file_view().seek(pos)
+    }
+
+    #[inline]
+    fn stream_position(&self) -> io::Result<u64> {
+        self.as_file_view().stream_position()
+    }
+}
+
 #[cfg(windows)]
 fn reopen<Handle: AsRawHandle>(handle: &Handle) -> io::Result<fs::File> {
     let handle = handle.as_raw_handle();

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -461,27 +461,27 @@ where
 
     #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        Read::read(&mut *self.as_file(), buf)
+        Read::read(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_exact(&self, buf: &mut [u8]) -> io::Result<()> {
-        Read::read_exact(&mut *self.as_file(), buf)
+        Read::read_exact(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
-        FileExt::read_at(&*self.as_file(), buf, offset)
+        FileExt::read_at(&*self.as_file_view(), buf, offset)
     }
 
     #[inline]
     fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> io::Result<()> {
-        FileExt::read_exact_at(&*self.as_file(), buf, offset)
+        FileExt::read_exact_at(&*self.as_file_view(), buf, offset)
     }
 
     #[inline]
     fn read_vectored(&self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        Read::read_vectored(&mut *self.as_file(), bufs)
+        Read::read_vectored(&mut *self.as_file_view(), bufs)
     }
 
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
@@ -498,43 +498,43 @@ where
 
     #[inline]
     fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        Read::read_to_end(&mut *self.as_file(), buf)
+        Read::read_to_end(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
-        Read::read_to_string(&mut *self.as_file(), buf)
+        Read::read_to_string(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
-        let pos = self.seek(SeekFrom::Current(0));
+        let pos = self.seek(SeekFrom::Current(0))?;
         self.read_at(buf, pos)
     }
 
     #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        Write::write(&mut *self.as_file(), buf)
+        Write::write(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn write_all(&self, buf: &[u8]) -> io::Result<()> {
-        Write::write_all(&mut *self.as_file(), buf)
+        Write::write_all(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
-        FileExt::write_at(&*self.as_file(), buf, offset)
+        FileExt::write_at(&*self.as_file_view(), buf, offset)
     }
 
     #[inline]
     fn write_all_at(&self, buf: &[u8], offset: u64) -> io::Result<()> {
-        FileExt::write_all_at(&*self.as_file(), buf, offset)
+        FileExt::write_all_at(&*self.as_file_view(), buf, offset)
     }
 
     #[inline]
     fn write_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
-        Write::write_vectored(&mut *self.as_file(), bufs)
+        Write::write_vectored(&mut *self.as_file_view(), bufs)
     }
 
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
@@ -551,17 +551,17 @@ where
 
     #[inline]
     fn flush(&self) -> io::Result<()> {
-        Write::flush(&mut *self.as_file())
+        Write::flush(&mut *self.as_file_view())
     }
 
     #[inline]
     fn write_fmt(&self, fmt: Arguments) -> io::Result<()> {
-        Write::write_fmt(&mut *self.as_file(), fmt)
+        Write::write_fmt(&mut *self.as_file_view(), fmt)
     }
 
     #[inline]
     fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
-        Seek::seek(&mut *self.as_file(), pos)
+        Seek::seek(&mut *self.as_file_view(), pos)
     }
 
     #[inline]
@@ -593,12 +593,12 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        Read::read(&mut *self.as_file(), buf)
+        Read::read(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_exact(&self, buf: &mut [u8]) -> io::Result<()> {
-        Read::read_exact(&mut *self.as_file(), buf)
+        Read::read_exact(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
@@ -632,7 +632,7 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn read_vectored(&self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        Read::read_vectored(&mut *self.as_file(), bufs)
+        Read::read_vectored(&mut *self.as_file_view(), bufs)
     }
 
     #[inline]
@@ -672,12 +672,12 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        Read::read_to_end(&mut *self.as_file(), buf)
+        Read::read_to_end(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
-        Read::read_to_string(&mut *self.as_file(), buf)
+        Read::read_to_string(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
@@ -688,12 +688,12 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        Write::write(&mut *self.as_file(), buf)
+        Write::write(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn write_all(&self, buf: &[u8]) -> io::Result<()> {
-        Write::write_all(&mut *self.as_file(), buf)
+        Write::write_all(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
@@ -727,7 +727,7 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn write_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
-        Write::write_vectored(&mut *self.as_file(), bufs)
+        Write::write_vectored(&mut *self.as_file_view(), bufs)
     }
 
     #[inline]
@@ -767,24 +767,24 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn flush(&self) -> io::Result<()> {
-        Write::flush(&mut *self.as_file())
+        Write::flush(&mut *self.as_file_view())
     }
 
     #[inline]
     fn write_fmt(&self, fmt: Arguments) -> io::Result<()> {
-        Write::write_fmt(&mut *self.as_file(), fmt)
+        Write::write_fmt(&mut *self.as_file_view(), fmt)
     }
 
     #[inline]
     fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
-        Seek::seek(&mut *self.as_file(), pos)
+        Seek::seek(&mut *self.as_file_view(), pos)
     }
 
     #[inline]
     fn stream_position(&self) -> io::Result<u64> {
         // This may eventually be obsoleted by [rust-lang/rust#59359].
         // [rust-lang/rust#59359]: https://github.com/rust-lang/rust/issues/59359.
-        Seek::seek(&mut *self.as_file(), SeekFrom::Current(0))
+        Seek::seek(&mut *self.as_file_view(), SeekFrom::Current(0))
     }
 }
 
@@ -809,12 +809,12 @@ impl FileIoExt for cap_std::fs::File {
 
     #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        Read::read(&mut *self.as_file(), buf)
+        Read::read(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_exact(&self, buf: &mut [u8]) -> io::Result<()> {
-        Read::read_exact(&mut *self.as_file(), buf)
+        Read::read_exact(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
@@ -848,7 +848,7 @@ impl FileIoExt for cap_std::fs::File {
 
     #[inline]
     fn read_vectored(&self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        Read::read_vectored(&mut *self.as_file(), bufs)
+        Read::read_vectored(&mut *self.as_file_view(), bufs)
     }
 
     #[inline]
@@ -888,22 +888,22 @@ impl FileIoExt for cap_std::fs::File {
 
     #[inline]
     fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        Read::read_to_end(&mut *self.as_file(), buf)
+        Read::read_to_end(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
-        Read::read_to_string(&mut *self.as_file(), buf)
+        Read::read_to_string(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        Write::write(&mut *self.as_file(), buf)
+        Write::write(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
     fn write_all(&self, buf: &[u8]) -> io::Result<()> {
-        Write::write_all(&mut *self.as_file(), buf)
+        Write::write_all(&mut *self.as_file_view(), buf)
     }
 
     #[inline]
@@ -937,7 +937,7 @@ impl FileIoExt for cap_std::fs::File {
 
     #[inline]
     fn write_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
-        Write::write_vectored(&mut *self.as_file(), bufs)
+        Write::write_vectored(&mut *self.as_file_view(), bufs)
     }
 
     #[inline]
@@ -977,24 +977,24 @@ impl FileIoExt for cap_std::fs::File {
 
     #[inline]
     fn flush(&self) -> io::Result<()> {
-        Write::flush(&mut *self.as_file())
+        Write::flush(&mut *self.as_file_view())
     }
 
     #[inline]
     fn write_fmt(&self, fmt: Arguments) -> io::Result<()> {
-        Write::write_fmt(&mut *self.as_file(), fmt)
+        Write::write_fmt(&mut *self.as_file_view(), fmt)
     }
 
     #[inline]
     fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
-        Seek::seek(&mut *self.as_file(), pos)
+        Seek::seek(&mut *self.as_file_view(), pos)
     }
 
     #[inline]
     fn stream_position(&self) -> io::Result<u64> {
         // This may eventually be obsoleted by [rust-lang/rust#59359].
         // [rust-lang/rust#59359]: https://github.com/rust-lang/rust/issues/59359.
-        Seek::seek(&mut *self.as_file(), SeekFrom::Current(0))
+        Seek::seek(&mut *self.as_file_view(), SeekFrom::Current(0))
     }
 }
 

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -897,6 +897,12 @@ impl FileIoExt for cap_std::fs::File {
     }
 
     #[inline]
+    fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
+        let reopened = reopen_write(self)?;
+        reopened.read(buf)
+    }
+
+    #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
         Write::write(&mut *self.as_file_view(), buf)
     }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -18,7 +18,7 @@ use unsafe_io::AsUnsafeFile;
 impl crate::io::ReadReady for std::fs::File {
     #[inline]
     fn num_ready_bytes(&self) -> std::io::Result<u64> {
-        let file = self.as_file();
+        let file = self.as_file_view();
         let (read, _write) = is_read_write(&*file)?;
         if read {
             let metadata = file.metadata()?;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,7 +1,9 @@
 //! I/O extension traits.
 
 mod is_terminal;
+mod peek;
 mod read_ready;
 
 pub use is_terminal::IsTerminal;
+pub use peek::{peek_from_bufread, Peek};
 pub use read_ready::ReadReady;

--- a/src/io/peek.rs
+++ b/src/io/peek.rs
@@ -1,0 +1,166 @@
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
+use std::{
+    cmp::min,
+    fs::File,
+    io::{self, BufRead, BufReader, Chain, Cursor, Empty, Read, Repeat, StdinLock, Take},
+    net::TcpStream,
+};
+
+/// A trait providing the `peek` function for reading without consuming.
+///
+/// Many common `Read` implementations have `Peek` implementations, however
+/// [`Stdin`], [`ChildStderr`], [`ChildStdout`], [`PipeReader`], and
+/// [`CharDevice`] do not, since they are unbuffered and pipes and character
+/// devices don't support any form of peeking.
+///
+/// [`Stdin`]: std::io::Stdin
+/// [`ChildStdout`]: std::process::ChildStdout
+/// [`ChildStderr`]: std::process::ChildStderr
+/// [`PipeReader`]: https://docs.rs/os_pipe/latest/os_pipe/struct.PipeReader.html
+/// [`CharDevice`]: https://docs.rs/char-device/latest/char_device/struct.CharDevice.html
+pub trait Peek {
+    /// Reads data from a stream without consuming it; subsequent reads will
+    /// re-read the data. May return fewer bytes than requested; `Ok(0)`
+    /// indicates that seeking is not possible (but reading may still be).
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+}
+
+impl Peek for File {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        crate::fs::FileIoExt::peek(self, buf)
+    }
+}
+
+#[cfg(feature = "cap_std_impls_fs_utf8")]
+impl Peek for cap_std::fs::File {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.as_file_view().peek(buf)
+    }
+}
+
+#[cfg(feature = "cap_std_impls_fs_utf8")]
+impl Peek for cap_std::fs_utf8::File {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.as_file_view().peek(buf)
+    }
+}
+
+impl Peek for TcpStream {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        TcpStream::peek(self, buf)
+    }
+}
+
+#[cfg(unix)]
+impl Peek for UnixStream {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        #[cfg(unix_socket_peek)]
+        {
+            UnixStream::peek(self, buf)
+        }
+
+        #[cfg(not(unix_socket_peek))]
+        {
+            // Return the conservatively correct value.
+            Ok(0)
+        }
+    }
+}
+
+impl Peek for Repeat {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // Repeat just reads the same byte repeatedly, so we can just read
+        // from it.
+        self.read(buf)
+    }
+}
+
+#[cfg(feature = "socketpair")]
+impl Peek for socketpair::SocketpairStream {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        socketpair::SocketpairStream::peek(self, buf)
+    }
+}
+
+impl<'a> Peek for Empty {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<'a> Peek for &'a [u8] {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<'a> Peek for StdinLock<'a> {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<B: BufRead + ?Sized> Peek for Box<B> {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<'a, B: BufRead + ?Sized> Peek for &'a mut B {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<R: Read> Peek for BufReader<R> {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<T> Peek for Cursor<T>
+where
+    T: AsRef<[u8]>,
+{
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<T: BufRead> Peek for Take<T> {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+impl<T: BufRead, U: BufRead> Peek for Chain<T, U> {
+    #[inline]
+    fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        peek_from_bufread(self, buf)
+    }
+}
+
+/// Implement `peek` for types that implement `BufRead`.
+pub fn peek_from_bufread<BR: BufRead>(buf_read: &mut BR, buf: &mut [u8]) -> io::Result<usize> {
+    // Call `fill_buf` to read the bytes, but don't call `consume`.
+    let reader_buf = buf_read.fill_buf()?;
+    let len = min(buf.len(), reader_buf.len());
+    buf[..len].copy_from_slice(&reader_buf[..len]);
+    Ok(len)
+}

--- a/src/io/read_ready.rs
+++ b/src/io/read_ready.rs
@@ -31,7 +31,7 @@ impl ReadReady for Stdin {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
         // Return the conservatively correct result.
-        Ok(1)
+        Ok(0)
     }
 }
 
@@ -50,7 +50,7 @@ impl<'a> ReadReady for StdinLock<'a> {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
         // Return the conservatively correct result.
-        Ok(1)
+        Ok(0)
     }
 }
 

--- a/src/io/read_ready.rs
+++ b/src/io/read_ready.rs
@@ -76,3 +76,36 @@ impl ReadReady for net::TcpStream {
         }
     }
 }
+
+#[cfg(all(not(windows), feature = "os_pipe"))]
+impl ReadReady for os_pipe::PipeReader {
+    #[inline]
+    fn num_ready_bytes(&self) -> io::Result<u64> {
+        fionread(self)
+    }
+}
+
+#[cfg(all(windows, feature = "os_pipe"))]
+impl ReadReady for os_pipe::PipeReader {
+    #[inline]
+    fn num_ready_bytes(&self) -> io::Result<u64> {
+        // Return the conservatively correct result.
+        Ok(0)
+    }
+}
+
+#[cfg(feature = "socketpair")]
+impl ReadReady for socketpair::SocketpairStream {
+    #[inline]
+    fn num_ready_bytes(&self) -> io::Result<u64> {
+        socketpair::SocketpairStream::num_ready_bytes(self)
+    }
+}
+
+#[cfg(feature = "char-device")]
+impl ReadReady for char_device::CharDevice {
+    #[inline]
+    fn num_ready_bytes(&self) -> io::Result<u64> {
+        char_device::CharDevice::num_ready_bytes(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
+#![cfg_attr(all(unix, unix_socket_peek), feature(unix_socket_peek))]
 
 pub mod fs;
 pub mod io;

--- a/tests/live_rename.rs
+++ b/tests/live_rename.rs
@@ -56,11 +56,11 @@ fn concurrent_rename() {
         .open(dir.path().join("file")));
     check!(write!(&file, "abcdefghijklmnopqrstuvwxyz"));
 
-    let mut join = vec![];
+    let mut joins = vec![];
 
     let path = dir.path().to_path_buf();
     let file = check!(File::open(path.join("file")));
-    join.push(thread::spawn(move || {
+    joins.push(thread::spawn(move || {
         let mut buf = [0u8; 8];
         for _ in 0..10000 {
             check!(file.read_exact_at(&mut buf, 8));
@@ -69,7 +69,7 @@ fn concurrent_rename() {
     }));
 
     let path = dir.path().to_path_buf();
-    join.push(thread::spawn(move || {
+    joins.push(thread::spawn(move || {
         let start = path.join("file");
         check!(rename(start, path.join(format!("file.{}", 0))));
         for i in 0..10000 {
@@ -80,5 +80,7 @@ fn concurrent_rename() {
         }
     }));
 
-    join.drain(..).map(|join| join.join().unwrap()).count();
+    for join in joins {
+        join.join().unwrap();
+    }
 }

--- a/tests/peek.rs
+++ b/tests/peek.rs
@@ -1,0 +1,26 @@
+use std::{
+    io::{Cursor, Read},
+    str,
+};
+use system_interface::io::Peek;
+
+#[test]
+fn test_peek() {
+    let mut input = Cursor::new("hello".to_string());
+    let mut buf = vec![0u8; 20];
+
+    // Do a peek.
+    assert_eq!(Peek::peek(&mut input, &mut buf).unwrap(), 5);
+    assert_eq!(str::from_utf8(&buf[..5]).unwrap(), "hello");
+    assert_eq!(input.position(), 0);
+
+    // Peek doesn't advance the cursor.
+    assert_eq!(Peek::peek(&mut input, &mut buf).unwrap(), 5);
+    assert_eq!(str::from_utf8(&buf[..5]).unwrap(), "hello");
+    assert_eq!(input.position(), 0);
+
+    // Read does.
+    assert_eq!(Read::read(&mut input, &mut buf).unwrap(), 5);
+    assert_eq!(str::from_utf8(&buf[..5]).unwrap(), "hello");
+    assert_eq!(input.position(), 5);
+}

--- a/tests/vectored_at.rs
+++ b/tests/vectored_at.rs
@@ -254,8 +254,8 @@ fn write_vectored_at() {
     check!(write!(&file, "abcdefghijklmnopqrstuvwxyz"));
     let buf0 = b"EFGHIJKL".to_vec();
     let buf1 = b"MNOPQRST".to_vec();
-    let mut bufs = vec![IoSlice::new(&buf0), IoSlice::new(&buf1)];
-    let nwritten = check!(file.write_vectored_at(&mut bufs, 4));
+    let bufs = vec![IoSlice::new(&buf0), IoSlice::new(&buf1)];
+    let nwritten = check!(file.write_vectored_at(&bufs, 4));
     assert_eq!(check!(file.stream_position()), 26);
     let mut back = String::new();
     check!(file.seek(std::io::SeekFrom::Start(0)));
@@ -340,8 +340,8 @@ fn write_vectored() {
     check!(write!(&file, "abcdefghijklmnopqrstuvwxyz"));
     let buf0 = b"EFGHIJKL".to_vec();
     let buf1 = b"MNOPQRST".to_vec();
-    let mut bufs = vec![IoSlice::new(&buf0), IoSlice::new(&buf1)];
-    let nwritten = check!(file.write_vectored(&mut bufs));
+    let bufs = vec![IoSlice::new(&buf0), IoSlice::new(&buf1)];
+    let nwritten = check!(file.write_vectored(&bufs));
     assert_eq!(check!(file.stream_position()), (26 + nwritten) as u64);
     let mut back = String::new();
     check!(file.seek(std::io::SeekFrom::Start(0)));


### PR DESCRIPTION
Add a `peek` function to `FileIoExt`, a `Peek` trait, and implementations for `PipeReader`, `CharDevice`, and `SocketpairStream`.