### PR TITLE
FileIoExt: make `allocate` just return an error on windows

### DIFF
--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -595,13 +595,18 @@ impl FileIoExt for fs::File {
 
     #[inline]
     fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
+        let len = self.metadata()?.len();
         // In theory we could do a `reopen` + `seek` first, allowing the OS to
         // create a sparse file, but Windows doesn't guarantee to zero-fill.
         // The following doesn't guarantee to make the file dense in the
         // given range, but Windows doesn't have a simple way to do that either.
-        self.set_len(offset.checked_add(len).ok_or_else(|| {
+        let allocated_len = offset.checked_add(len).ok_or_else(|| {
             io::Error::new(io::ErrorKind::Other, "overflow while allocating file space")
-        })?)
+        })?;
+        if allocated_len > len {
+            self.set_len(allocated_len)?;
+        }
+        Ok(())
     }
 
     #[inline]

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -594,7 +594,7 @@ impl FileIoExt for fs::File {
     }
 
     #[inline]
-    fn allocate(&self, offset: u64, len: u64) -> io::Result<()> {
+    fn allocate(&self, _offset: u64, _len: u64) -> io::Result<()> {
         // We can't faithfully support allocate on Windows without exposing race conditions.
         // Instead, refuse:
         Err(io::Error::new(

--- a/tests/allocate.rs
+++ b/tests/allocate.rs
@@ -5,6 +5,7 @@ use std::fs::OpenOptions;
 use system_interface::fs::FileIoExt;
 
 #[test]
+#[cfg(not(windows))]
 fn allocate() {
     let dir = tempfile::tempdir().unwrap();
     let file = check!(OpenOptions::new()
@@ -26,4 +27,20 @@ fn allocate() {
     check!(file.allocate(4096, 4096));
 
     assert_eq!(check!(file.metadata()).len(), 4096 + 4096);
+}
+
+#[test]
+#[cfg(windows)]
+fn allocate() {
+    let dir = tempfile::tempdir().unwrap();
+    let file = check!(OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(dir.path().join("file")));
+
+    assert_eq!(check!(file.metadata()).len(), 0);
+
+    file.allocate(1024, 1024)
+        .expect_err("allocate should fail on windows");
 }


### PR DESCRIPTION
Wasi tests showed that this was truncating the file!

We don't believe that it is possible to implement this faithfully on Windows without exposing a race condition. So, refuse to implement it at all.