### PR TITLE
Upgrade winx to version 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ winapi = { version = "0.3.9", features = [
     "winerror",
     "winsock2",
 ] }
-winx = "0.23.0"
+winx = "0.25.0"
 
 [dev-dependencies]
 cap-fs-ext = "0.13.7"


### PR DESCRIPTION
This is the same version used by other cap- crates, and results in fewer
different versions when embedded by final users.