### PR TITLE
Update to the latest posish, cap-std, and io-lifetimes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,8 @@ jobs:
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=i686-pc-windows-msvc
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=i686-pc-windows-gnu
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=x86_64-fuchsia
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=wasm32-unknown-emscripten
+    # socket2 doesn't yet support wasm32-unknown-emscripten
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=wasm32-unknown-emscripten
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,42 +16,42 @@ rustc_version = "0.4.0"
 [dependencies]
 async-std = { version = "1.9.0", optional = true }
 bitflags = "1.2.1"
-cap-std = { version = "0.13.7", optional = true }
-cap-async-std = { version = "0.13.7", optional = true }
+cap-std = { version = "0.15.2", optional = true }
+cap-async-std = { version = "0.15.2", optional = true }
 char-device = { version = "0.4.0", optional = true }
 os_pipe = { version = "0.9.2", optional = true }
 socketpair = { version = "0.7.0", optional = true }
-unsafe-io = "0.6.3"
+io-lifetimes = "0.2.0"
 ssh2 = { version = "0.9.1", optional = true }
 socket2 = { version = "0.4.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.6.3"
+posish = "0.15.0"
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"
-cap-fs-ext = "0.13.7"
+cap-fs-ext = "0.15.2"
 winapi = { version = "0.3.9", features = [
     "winerror",
     "winsock2",
 ] }
-winx = "0.25.0"
+winx = "0.27.0"
 
 [dev-dependencies]
-cap-fs-ext = "0.13.7"
-cap-tempfile = "0.13.7"
-cap-std = "0.13.7"
+cap-fs-ext = "0.15.2"
+cap-tempfile = "0.15.2"
+cap-std = "0.15.2"
 tempfile = "3.2.0"
 atty = "0.2.14"
 
 [features]
 default = []
 cap_std_impls = ["cap-std"]
-cap_async_std_impls = ["async-std", "cap-async-std", "unsafe-io/async-std"]
+cap_async_std_impls = ["async-std", "cap-async-std", "io-lifetimes/async-std"]
 cap_std_impls_fs_utf8 = ["cap-std/fs_utf8"]
 cap_async_std_impls_fs_utf8 = ["async-std", "cap-async-std/fs_utf8"]
-use_os_pipe = ["os_pipe", "unsafe-io/os_pipe"]
-use_socket2 = ["socket2", "unsafe-io/socket2"]
+use_os_pipe = ["os_pipe", "io-lifetimes/os_pipe"]
+use_socket2 = ["socket2", "io-lifetimes/socket2"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ssh2 = { version = "0.9.1", optional = true }
 socket2 = { version = "0.4.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-posish = "0.15.0"
+posish = "0.15.1"
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"

--- a/src/fs/fd_flags.rs
+++ b/src/fs/fd_flags.rs
@@ -86,6 +86,7 @@ impl<T> GetSetFdFlags for T {
         let flags = fcntl_getfl(self)?;
 
         fd_flags.set(FdFlags::APPEND, flags.contains(OFlags::APPEND));
+        #[cfg(not(target_os = "freebsd"))]
         fd_flags.set(FdFlags::DSYNC, flags.contains(OFlags::DSYNC));
         fd_flags.set(FdFlags::NONBLOCK, flags.contains(OFlags::NONBLOCK));
         #[cfg(any(

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -5,7 +5,7 @@ mod file_io_ext;
 
 use crate::io::IsReadWrite;
 
-pub use fd_flags::{FdFlags, GetSetFdFlags};
+pub use fd_flags::{FdFlags, GetSetFdFlags, SetFdFlags};
 pub use file_io_ext::{Advice, FileIoExt};
 
 // Windows quirks:

--- a/src/io/peek.rs
+++ b/src/io/peek.rs
@@ -1,3 +1,5 @@
+#[cfg(any(feature = "cap_std_impls", feature = "cap_std_impls_utf8"))]
+use io_lifetimes::AsFilelike;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::{
@@ -5,8 +7,6 @@ use std::{
     io::{self, BufRead, BufReader, Chain, Cursor, Empty, Read, Repeat, StdinLock, Take},
     net::TcpStream,
 };
-#[cfg(any(feature = "cap_std_impls", feature = "cap_std_impls_utf8"))]
-use unsafe_io::AsUnsafeFile;
 
 /// A trait providing the `peek` function for reading without consuming.
 ///
@@ -38,7 +38,7 @@ impl Peek for File {
 impl Peek for cap_std::fs::File {
     #[inline]
     fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_file_view().peek(buf)
+        self.as_filelike_view::<std::fs::File>().peek(buf)
     }
 }
 
@@ -46,7 +46,7 @@ impl Peek for cap_std::fs::File {
 impl Peek for cap_std::fs_utf8::File {
     #[inline]
     fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_file_view().peek(buf)
+        self.as_filelike_view::<std::fs::File>().peek(buf)
     }
 }
 
@@ -169,7 +169,7 @@ pub fn peek_from_bufread<BR: BufRead>(buf_read: &mut BR, buf: &mut [u8]) -> io::
 impl Peek for socket2::Socket {
     #[inline]
     fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        use unsafe_io::AsUnsafeSocket;
-        self.as_tcp_stream_view().peek(buf)
+        use io_lifetimes::AsSocketlike;
+        self.as_socketlike_view::<std::net::TcpStream>().peek(buf)
     }
 }

--- a/src/io/read_ready.rs
+++ b/src/io/read_ready.rs
@@ -1,5 +1,5 @@
 #[cfg(not(any(windows, target_os = "redox")))]
-use posish::io::fionread;
+use posish::io::ioctl_fionread;
 #[cfg(not(target_os = "redox"))]
 use std::net;
 use std::{
@@ -24,7 +24,7 @@ pub trait ReadReady {
 impl ReadReady for Stdin {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -43,7 +43,7 @@ impl ReadReady for Stdin {
 impl<'a> ReadReady for StdinLock<'a> {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -62,7 +62,7 @@ impl<'a> ReadReady for StdinLock<'a> {
 impl ReadReady for net::TcpStream {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -81,7 +81,7 @@ impl ReadReady for net::TcpStream {
 impl ReadReady for std::os::unix::net::UnixStream {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -104,8 +104,9 @@ impl ReadReady for net::TcpStream {
 impl ReadReady for socket2::Socket {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        use unsafe_io::AsUnsafeSocket;
-        self.as_tcp_stream_view().num_ready_bytes()
+        use io_lifetimes::AsSocketlike;
+        self.as_socketlike_view::<std::net::TcpStream>()
+            .num_ready_bytes()
     }
 }
 
@@ -113,7 +114,7 @@ impl ReadReady for socket2::Socket {
 impl ReadReady for os_pipe::PipeReader {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -130,7 +131,7 @@ impl ReadReady for os_pipe::PipeReader {
 impl ReadReady for ChildStdout {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -147,7 +148,7 @@ impl ReadReady for ChildStdout {
 impl ReadReady for ChildStderr {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        fionread(self)
+        Ok(ioctl_fionread(self)?)
     }
 }
 
@@ -189,8 +190,8 @@ impl ReadReady for char_device::CharDevice {
 impl ReadReady for cap_std::fs::File {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        use unsafe_io::AsUnsafeFile;
-        self.as_file_view().num_ready_bytes()
+        use io_lifetimes::AsFilelike;
+        self.as_filelike_view::<std::fs::File>().num_ready_bytes()
     }
 }
 
@@ -199,7 +200,7 @@ impl ReadReady for cap_std::fs::File {
 impl ReadReady for cap_std::fs_utf8::File {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        use unsafe_io::AsUnsafeFile;
-        self.as_file_view().num_ready_bytes()
+        use io_lifetimes::AsFilelike;
+        self.as_filelike_view::<std::fs::File>().num_ready_bytes()
     }
 }

--- a/tests/fd_flags.rs
+++ b/tests/fd_flags.rs
@@ -24,7 +24,9 @@ fn test_get_set_fd_flags() {
 
     // `NONBLOCK` is not supported on Windows yet.
     #[cfg(windows)]
-    assert!(file.set_fd_flags(FdFlags::NONBLOCK).is_err());
+    {
+        assert!(file.new_set_fd_flags(FdFlags::NONBLOCK).is_err());
+    }
     #[cfg(not(windows))]
     {
         let set_fd_flags = check!(file.new_set_fd_flags(FdFlags::NONBLOCK));

--- a/tests/fd_flags.rs
+++ b/tests/fd_flags.rs
@@ -14,7 +14,8 @@ fn test_get_set_fd_flags() {
     assert!(!flags.contains(FdFlags::APPEND));
     assert!(!flags.contains(FdFlags::NONBLOCK));
 
-    check!(file.set_fd_flags(FdFlags::APPEND));
+    let set_fd_flags = check!(file.new_set_fd_flags(FdFlags::APPEND));
+    check!(file.set_fd_flags(set_fd_flags));
 
     let flags = check!(file.get_fd_flags());
     assert!(!flags.contains(FdFlags::SYNC));
@@ -26,7 +27,8 @@ fn test_get_set_fd_flags() {
     assert!(file.set_fd_flags(FdFlags::NONBLOCK).is_err());
     #[cfg(not(windows))]
     {
-        check!(file.set_fd_flags(FdFlags::NONBLOCK));
+        let set_fd_flags = check!(file.new_set_fd_flags(FdFlags::NONBLOCK));
+        check!(file.set_fd_flags(set_fd_flags));
 
         let flags = check!(file.get_fd_flags());
         assert!(!flags.contains(FdFlags::SYNC));

--- a/tests/sys_common/io.rs
+++ b/tests/sys_common/io.rs
@@ -1,4 +1,4 @@
-use cap_tempfile::tempdir;
+use cap_tempfile::{ambient_authority, tempdir};
 
 pub use cap_tempfile::TempDir;
 
@@ -6,5 +6,6 @@ pub use cap_tempfile::TempDir;
 pub fn tmpdir() -> TempDir {
     // It's ok to wrap this in an unsafe block, rather than an unsafe function,
     // because this function is only used by tests.
-    unsafe { tempdir() }.expect("expected to be able to create a temporary directory")
+    unsafe { tempdir(ambient_authority()) }
+        .expect("expected to be able to create a temporary directory")
 }


### PR DESCRIPTION
This switches from unsafe-io and `UnsafeHandle` to io-lifetimes and
`AsFilelike`, which overall is safer and simpler.

However, this does require splitting `GetSetFdFlags::set_fd_flags` into
two steps, to allow the first step to create lifetimes which the compiler
can be sure end before the second step.