### PR TITLE
Update to rustix 0.35.6 and cap-std 0.25.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,31 +13,34 @@ exclude = ["/.github"]
 [dependencies]
 async-std = { version = "1.10.0", optional = true }
 bitflags = "1.2.1"
-cap-std = { version = "0.24.0", optional = true }
-cap-async-std = { version = "0.24.0", optional = true }
-char-device = { version = "0.11.0", optional = true }
+cap-std = { version = "0.25.0", optional = true }
+cap-async-std = { version = "0.25.0", optional = true }
+char-device = { version = "0.13.0", optional = true }
 os_pipe = { version = "1.0.0", optional = true }
-socketpair = { version = "0.14.0", optional = true }
-io-lifetimes = { version = "0.5.1", default-features = false }
+socketpair = { version = "0.16.0", optional = true }
+io-lifetimes = { version = "0.7.0", default-features = false }
 ssh2 = { version = "0.9.1", optional = true }
 socket2 = { version = "0.4.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = "0.33.0"
+rustix = { version = "0.35.6", features = ["fs", "net", "termios"] }
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"
-cap-fs-ext = "0.24.0"
-winapi = { version = "0.3.9", features = [
-    "winerror",
-    "winsock2",
-] }
-winx = "0.31.0"
+cap-fs-ext = "0.25.0"
+winx = "0.33.0"
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Storage_FileSystem",
+    "Win32_Networking_WinSock",
+]
 
 [dev-dependencies]
-cap-fs-ext = "0.24.0"
-cap-tempfile = "0.24.0"
-cap-std = "0.24.0"
+cap-fs-ext = "0.25.0"
+cap-tempfile = "0.25.0"
+cap-std = "0.25.0"
 tempfile = "3.2.0"
 atty = "0.2.14"
 
@@ -49,6 +52,3 @@ cap_std_impls_fs_utf8 = ["cap-std/fs_utf8"]
 cap_async_std_impls_fs_utf8 = ["async-std", "cap-async-std/fs_utf8"]
 use_os_pipe = ["os_pipe", "io-lifetimes/os_pipe"]
 use_socket2 = ["socket2", "io-lifetimes/socket2"]
-
-[badges]
-maintenance = { status = "actively-developed" }

--- a/src/fs/fd_flags.rs
+++ b/src/fs/fd_flags.rs
@@ -10,7 +10,7 @@ use {
     cap_fs_ext::{OpenOptions, Reopen},
     io_lifetimes::AsHandle,
     std::os::windows::fs::OpenOptionsExt,
-    winapi::um::winbase::FILE_FLAG_WRITE_THROUGH,
+    windows_sys::Win32::Storage::FileSystem::FILE_FLAG_WRITE_THROUGH,
     winx::file::{AccessMode, FileModeInformation},
 };
 

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -475,12 +475,12 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        Read::read(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
     fn read_exact(&self, buf: &mut [u8]) -> io::Result<()> {
-        Read::read_exact(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read_exact(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -495,7 +495,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read_vectored(&self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        Read::read_vectored(&mut *self.as_filelike_view::<std::fs::File>(), bufs)
+        Read::read_vectored(&mut &*self.as_filelike_view::<std::fs::File>(), bufs)
     }
 
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
@@ -512,7 +512,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        Read::read_to_end(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read_to_end(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -522,7 +522,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
-        Read::read_to_string(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read_to_string(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -538,12 +538,12 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        Write::write(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Write::write(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
     fn write_all(&self, buf: &[u8]) -> io::Result<()> {
-        Write::write_all(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Write::write_all(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -558,7 +558,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn write_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
-        Write::write_vectored(&mut *self.as_filelike_view::<std::fs::File>(), bufs)
+        Write::write_vectored(&mut &*self.as_filelike_view::<std::fs::File>(), bufs)
     }
 
     #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "redox")))]
@@ -575,17 +575,17 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn flush(&self) -> io::Result<()> {
-        Write::flush(&mut *self.as_filelike_view::<std::fs::File>())
+        Write::flush(&mut &*self.as_filelike_view::<std::fs::File>())
     }
 
     #[inline]
     fn write_fmt(&self, fmt: Arguments) -> io::Result<()> {
-        Write::write_fmt(&mut *self.as_filelike_view::<std::fs::File>(), fmt)
+        Write::write_fmt(&mut &*self.as_filelike_view::<std::fs::File>(), fmt)
     }
 
     #[inline]
     fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
-        Seek::seek(&mut *self.as_filelike_view::<std::fs::File>(), pos)
+        Seek::seek(&mut &*self.as_filelike_view::<std::fs::File>(), pos)
     }
 
     #[inline]
@@ -616,12 +616,12 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
-        Read::read(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
     fn read_exact(&self, buf: &mut [u8]) -> io::Result<()> {
-        Read::read_exact(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read_exact(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -655,7 +655,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read_vectored(&self, bufs: &mut [IoSliceMut]) -> io::Result<usize> {
-        Read::read_vectored(&mut *self.as_filelike_view::<std::fs::File>(), bufs)
+        Read::read_vectored(&mut &*self.as_filelike_view::<std::fs::File>(), bufs)
     }
 
     #[inline]
@@ -695,7 +695,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read_to_end(&self, buf: &mut Vec<u8>) -> io::Result<usize> {
-        Read::read_to_end(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read_to_end(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -705,7 +705,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn read_to_string(&self, buf: &mut String) -> io::Result<usize> {
-        Read::read_to_string(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Read::read_to_string(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -721,12 +721,12 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn write(&self, buf: &[u8]) -> io::Result<usize> {
-        Write::write(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Write::write(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
     fn write_all(&self, buf: &[u8]) -> io::Result<()> {
-        Write::write_all(&mut *self.as_filelike_view::<std::fs::File>(), buf)
+        Write::write_all(&mut &*self.as_filelike_view::<std::fs::File>(), buf)
     }
 
     #[inline]
@@ -760,7 +760,7 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn write_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
-        Write::write_vectored(&mut *self.as_filelike_view::<std::fs::File>(), bufs)
+        Write::write_vectored(&mut &*self.as_filelike_view::<std::fs::File>(), bufs)
     }
 
     #[inline]
@@ -800,17 +800,17 @@ impl<T: AsFilelike> FileIoExt for T {
 
     #[inline]
     fn flush(&self) -> io::Result<()> {
-        Write::flush(&mut *self.as_filelike_view::<std::fs::File>())
+        Write::flush(&mut &*self.as_filelike_view::<std::fs::File>())
     }
 
     #[inline]
     fn write_fmt(&self, fmt: Arguments) -> io::Result<()> {
-        Write::write_fmt(&mut *self.as_filelike_view::<std::fs::File>(), fmt)
+        Write::write_fmt(&mut &*self.as_filelike_view::<std::fs::File>(), fmt)
     }
 
     #[inline]
     fn seek(&self, pos: SeekFrom) -> io::Result<u64> {
-        Seek::seek(&mut *self.as_filelike_view::<std::fs::File>(), pos)
+        Seek::seek(&mut &*self.as_filelike_view::<std::fs::File>(), pos)
     }
 
     #[inline]
@@ -818,7 +818,7 @@ impl<T: AsFilelike> FileIoExt for T {
         // This may eventually be obsoleted by [rust-lang/rust#59359].
         // [rust-lang/rust#59359]: https://github.com/rust-lang/rust/issues/59359.
         Seek::seek(
-            &mut *self.as_filelike_view::<std::fs::File>(),
+            &mut &*self.as_filelike_view::<std::fs::File>(),
             SeekFrom::Current(0),
         )
     }

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -7,7 +7,7 @@ use {
         os::windows::io::{AsRawSocket, RawSocket},
         ptr,
     },
-    winapi::um::winsock2::{
+    windows_sys::Win32::Networking::WinSock::{
         recv, send, MSG_PEEK, SOCKET, SOCKET_ERROR, WSAEFAULT, WSAESHUTDOWN, WSAEWOULDBLOCK,
     },
 };

--- a/src/io/is_terminal.rs
+++ b/src/io/is_terminal.rs
@@ -5,7 +5,7 @@ use std::{
     net,
 };
 #[cfg(not(windows))]
-use {io_lifetimes::AsFilelike, rustix::io::isatty};
+use {io_lifetimes::AsFilelike, rustix::termios::isatty};
 
 /// Extension for I/O handles which may or may not be terminals.
 pub trait IsTerminal {

--- a/src/io/peek.rs
+++ b/src/io/peek.rs
@@ -1,5 +1,3 @@
-#[cfg(any(feature = "cap_std_impls", feature = "cap_std_impls_utf8"))]
-use io_lifetimes::AsFilelike;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Chain, Cursor, Empty, Read, Repeat, StdinLock, Take};
 use std::net::TcpStream;
@@ -36,7 +34,7 @@ impl Peek for File {
 impl Peek for cap_std::fs::File {
     #[inline]
     fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_filelike_view::<std::fs::File>().peek(buf)
+        crate::fs::FileIoExt::peek(self, buf)
     }
 }
 
@@ -44,7 +42,7 @@ impl Peek for cap_std::fs::File {
 impl Peek for cap_std::fs_utf8::File {
     #[inline]
     fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.as_filelike_view::<std::fs::File>().peek(buf)
+        crate::fs::FileIoExt::peek(self, buf)
     }
 }
 

--- a/src/io/read_ready.rs
+++ b/src/io/read_ready.rs
@@ -7,7 +7,7 @@ use std::process::{ChildStderr, ChildStdout};
 #[cfg(windows)]
 use {
     std::{mem::MaybeUninit, os::windows::io::AsRawSocket},
-    winapi::um::winsock2::{ioctlsocket, FIONREAD, SOCKET},
+    windows_sys::Win32::Networking::WinSock::{ioctlsocket, FIONREAD, SOCKET},
 };
 
 /// Extension for readable streams that can indicate the number of bytes
@@ -88,7 +88,7 @@ impl ReadReady for std::os::unix::net::UnixStream {
 impl ReadReady for net::TcpStream {
     #[inline]
     fn num_ready_bytes(&self) -> io::Result<u64> {
-        let mut arg = MaybeUninit::<winapi::ctypes::c_ulong>::uninit();
+        let mut arg = MaybeUninit::<std::os::raw::c_ulong>::uninit();
         if unsafe { ioctlsocket(self.as_raw_socket() as SOCKET, FIONREAD, arg.as_mut_ptr()) } == 0 {
             Ok(unsafe { arg.assume_init() }.into())
         } else {


### PR DESCRIPTION
This also switches from winapi to windows-sys.

This is mostly straightforward; most of the changes are due to
`as_filelike_view` returning a view that no longer implements `DerefMut`.