### PR TITLE
Handle unexpected EOF in `read_exact_vectored` and `read_exact_vectored_at`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
         include:
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2022-07-13
 
     steps:
     - uses: actions/checkout@v2
@@ -241,10 +241,10 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2022-07-13
           - build: windows
             os: windows-latest
-            rust: nightly
+            rust: nightly-2022-07-13
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows, macos, macos-11.0, beta, ubuntu-18.04, windows-2016, aarch64-ubuntu]
+        build: [stable, windows, macos, macos-11.0, beta, ubuntu-18.04, windows-2019, aarch64-ubuntu]
         include:
           - build: stable
             os: ubuntu-latest
@@ -176,8 +176,8 @@ jobs:
           - build: ubuntu-18.04
             os: ubuntu-18.04
             rust: stable
-          - build: windows-2016
-            os: windows-2016
+          - build: windows-2019
+            os: windows-2019
             rust: stable
           - build: aarch64-ubuntu
             os: ubuntu-latest


### PR DESCRIPTION
Teach `read_exact_vectored` and `read_exact_vectored_at` to recognize
when the stream ends before the requested buffers are full, and to
return an `UnexpectedEOF` error in that case.