### PR TITLE
Update dependencies.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,20 +134,25 @@ jobs:
         i686-pc-windows-gnu
         x86_64-fuchsia
         wasm32-unknown-emscripten
+    # socket2, cap_async_std_impls, and cap_async_std_impls_fs_utf8 temporarily
+    # disabled until I/O safety trait impls are available
     - run: cargo check --workspace --all-targets --all-features --release -vv
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=x86_64-unknown-linux-musl
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=x86_64-unknown-linux-gnux32
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=x86_64-linux-android
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=x86_64-apple-darwin
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=x86_64-unknown-freebsd
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=x86_64-unknown-netbsd
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=i686-unknown-linux-gnu
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair,cap_async_std_impls,cap_async_std_impls_fs_utf8 --release -vv --target=i686-unknown-linux-musl
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=x86_64-pc-windows-msvc
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=x86_64-pc-windows-gnu
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=i686-pc-windows-msvc
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=i686-pc-windows-gnu
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,use_socket2,socketpair --release -vv --target=x86_64-fuchsia
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-linux-musl
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-linux-gnux32
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-linux-android
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-apple-darwin
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-freebsd
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-netbsd
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=i686-unknown-linux-gnu
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=i686-unknown-linux-musl
+
+    # socket2 temporarily disabled until I/O safety trait impls are available
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-pc-windows-msvc
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-pc-windows-gnu
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=i686-pc-windows-msvc
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=i686-pc-windows-gnu
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-fuchsia
+
     # socket2 doesn't yet support wasm32-unknown-emscripten
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=wasm32-unknown-emscripten
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,27 +11,27 @@ edition = "2018"
 exclude = ["/.github"]
 
 [dependencies]
-async-std = { version = "1.10.0", optional = true }
+#async-std = { version = "1.10.0", optional = true }
 bitflags = "1.2.1"
-cap-std = { version = "0.26.0", optional = true }
-cap-async-std = { version = "0.26.0", optional = true }
-char-device = { version = "0.13.0", optional = true }
-os_pipe = { version = "1.0.0", optional = true }
-socketpair = { version = "0.16.0", optional = true }
-io-lifetimes = { version = "0.7.0", default-features = false }
+cap-std = { version = "1.0.0", optional = true }
+#cap-async-std = { version = "0.26.0", optional = true }
+char-device = { version = "0.14.0", optional = true }
+os_pipe = { version = "1.0.0", features = ["io_safety"], optional = true }
+socketpair = { version = "0.17.0", optional = true }
+io-lifetimes = { version = "1.0.0", default-features = false }
 ssh2 = { version = "0.9.1", optional = true }
-socket2 = { version = "0.4.0", optional = true }
+#socket2 = { version = "0.4.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.10", features = ["fs", "net", "termios"] }
+rustix = { version = "0.36.0", features = ["fs", "net", "termios"] }
 
 [target.'cfg(windows)'.dependencies]
 atty = "0.2.14"
-cap-fs-ext = "0.26.0"
-winx = "0.33.0"
+cap-fs-ext = "1.0.0"
+winx = "0.34.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.36.0"
+version = "0.42.0"
 features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
@@ -40,17 +40,17 @@ features = [
 ]
 
 [dev-dependencies]
-cap-fs-ext = "0.26.0"
-cap-tempfile = "0.26.0"
-cap-std = "0.26.0"
+cap-fs-ext = "1.0.0"
+cap-tempfile = "1.0.0"
+cap-std = "1.0.0"
 tempfile = "3.2.0"
 atty = "0.2.14"
 
 [features]
 default = []
 cap_std_impls = ["cap-std"]
-cap_async_std_impls = ["async-std", "cap-async-std", "io-lifetimes/async-std"]
+#cap_async_std_impls = ["async-std", "cap-async-std", "io-lifetimes/async-std"]
 cap_std_impls_fs_utf8 = ["cap-std/fs_utf8"]
-cap_async_std_impls_fs_utf8 = ["async-std", "cap-async-std/fs_utf8"]
+#cap_async_std_impls_fs_utf8 = ["async-std", "cap-async-std/fs_utf8"]
 use_os_pipe = ["os_pipe", "io-lifetimes/os_pipe"]
-use_socket2 = ["socket2", "io-lifetimes/socket2"]
+#use_socket2 = ["socket2", "io-lifetimes/socket2"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ used with regular [`std`] too. To separate concerns, all sandboxing and
 capability-oriented APIs are left to `cap-std`, so this crate's features are
 usable independently.
 
+Support for async-std and socket2 is temporarily disabled until those crates
+contain the needed implementations of the I/O safety traits.
+
 [`std`]: https://doc.rust-lang.org/std/
 [`cap-std`]: https://crates.io/crates/cap-std
 [WASI]: https://github.com/WebAssembly/WASI/


### PR DESCRIPTION
Update to cap-std 1.0 et al, and temporarily disable support for async-std.