### PR TITLE
Add an `append` API to `FileIoExt`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ssh2 = { version = "0.9.1", optional = true }
 #socket2 = { version = "0.4.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.36.0", features = ["fs", "net"] }
+rustix = { version = "0.36.6", features = ["fs", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 cap-fs-ext = "1.0.0"


### PR DESCRIPTION
Add functions to append to a file to `FileIoExt`. This is implemented using `pwritev2` with `RWF_APPEND` on Linux, and `F_SETFL`+`O_APPEND` on other Unix platforms.

`F_SETFL`+`O_APPEND` is not atomic with respect to other users of the file description; this is a documented limitation.