### PR TITLE
Adjust `O_NONBLOCK`, `O_SYNC`, `O_RSYNC` behavior on Windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,6 @@ jobs:
         x86_64-pc-windows-gnu
         i686-pc-windows-msvc
         i686-pc-windows-gnu
-        x86_64-fuchsia
         wasm32-unknown-emscripten
         riscv64gc-unknown-linux-gnu
         arm-unknown-linux-gnueabihf
@@ -85,7 +84,6 @@ jobs:
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=x86_64-pc-windows-gnu
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=i686-pc-windows-msvc
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=i686-pc-windows-gnu
-    - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=x86_64-fuchsia
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=wasm32-unknown-emscripten
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=riscv64gc-unknown-linux-gnu
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=arm-unknown-linux-gnueabihf
@@ -132,8 +130,12 @@ jobs:
         x86_64-pc-windows-gnu
         i686-pc-windows-msvc
         i686-pc-windows-gnu
-        x86_64-fuchsia
+        x86_64-unknown-fuchsia
         wasm32-unknown-emscripten
+    # x86_64-fuchsia was renamed to x86_64-unknown-fuchsia so for now just
+    # test it on nightly which has the new name.
+    - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=x86_64-unknown-fuchsia
+
     # socket2, cap_async_std_impls, and cap_async_std_impls_fs_utf8 temporarily
     # disabled until I/O safety trait impls are available
     - run: cargo check --workspace --all-targets --all-features --release -vv
@@ -151,7 +153,7 @@ jobs:
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-pc-windows-gnu
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=i686-pc-windows-msvc
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=i686-pc-windows-gnu
-    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-fuchsia
+    - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-fuchsia
 
     # socket2 doesn't yet support wasm32-unknown-emscripten
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=wasm32-unknown-emscripten

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
         include:
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2022-07-13
+            rust: nightly
 
     steps:
     - uses: actions/checkout@v3
@@ -248,10 +248,10 @@ jobs:
         include:
           - build: ubuntu
             os: ubuntu-latest
-            rust: nightly-2022-07-13
+            rust: nightly
           - build: windows
             os: windows-latest
-            rust: nightly-2022-07-13
+            rust: nightly
 
     steps:
     - uses: actions/checkout@v3

--- a/src/fs/fd_flags.rs
+++ b/src/fs/fd_flags.rs
@@ -164,9 +164,9 @@ impl<T> GetSetFdFlags for T {
         }
 
         if mode.contains(FileModeInformation::FILE_WRITE_THROUGH) {
-            // Only report `SYNC`. This is technically the only one of the
+            // Only report `DSYNC`. This is technically the only one of the
             // `O_?SYNC` flags Windows supports.
-            fd_flags |= FdFlags::SYNC;
+            fd_flags |= FdFlags::DSYNC;
         }
 
         Ok(fd_flags)
@@ -178,18 +178,8 @@ impl<T> GetSetFdFlags for T {
     {
         let mut flags = 0;
 
-        if fd_flags.contains(FdFlags::SYNC)
-            || fd_flags.contains(FdFlags::DSYNC)
-            || fd_flags.contains(FdFlags::RSYNC)
-        {
+        if fd_flags.contains(FdFlags::SYNC) || fd_flags.contains(FdFlags::DSYNC) {
             flags |= FILE_FLAG_WRITE_THROUGH;
-        }
-
-        if fd_flags.contains(FdFlags::NONBLOCK) {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "Non-blocking I/O is not yet supported on Windows",
-            ));
         }
 
         let file = self.as_filelike_view::<fs::File>();

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -536,7 +536,7 @@ impl<T: AsFilelike + IoExt> FileIoExt for T {
 
             let iovs = [IoSlice::new(buf)];
             match pwritev2(self, &iovs, 0, ReadWriteFlags::APPEND) {
-                Err(Errno::NOSYS) => {}
+                Err(Errno::NOSYS) | Err(Errno::NOTSUP) => {}
                 otherwise => return Ok(otherwise?),
             }
         }
@@ -568,7 +568,7 @@ impl<T: AsFilelike + IoExt> FileIoExt for T {
             use rustix::io::{pwritev2, Errno, ReadWriteFlags};
 
             match pwritev2(self, bufs, 0, ReadWriteFlags::APPEND) {
-                Err(Errno::NOSYS) => {}
+                Err(Errno::NOSYS) | Err(Errno::NOTSUP) => {}
                 otherwise => return Ok(otherwise?),
             }
         }

--- a/tests/fd_flags.rs
+++ b/tests/fd_flags.rs
@@ -25,7 +25,8 @@ fn test_get_set_fd_flags() {
     // `NONBLOCK` is not supported on Windows yet.
     #[cfg(windows)]
     {
-        assert!(file.new_set_fd_flags(FdFlags::NONBLOCK).is_err());
+        let set_fd_flags = check!(file.new_set_fd_flags(FdFlags::NONBLOCK));
+        check!(file.set_fd_flags(set_fd_flags));
     }
     #[cfg(not(windows))]
     {


### PR DESCRIPTION
Don't fail on Windows if `O_NONBLOCK` is set; Unix doesn't usually implement nonblocking behavior for regular files either, so it's ok to just ignore.

Don't set `FILE_FLAG_WRITE_THROUGH` if only `RSYNC` is requested since `O_RSYNC` is defined by POSIX to request the level of integrity requested by the `O_SYNC` and `O_DSYNC` flags.

And don't report that Windows supports `O_SYNC`; my reading of `FILE_FLAG_WRITE_THROUGH` is that it's more like `O_DSYNC` than `O_SYNC`.