### PR TITLE
Update to rustix 0.37.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,15 @@ exclude = ["/.github"]
 bitflags = "1.2.1"
 cap-std = { version = "1.0.0", optional = true }
 #cap-async-std = { version = "0.26.0", optional = true }
-char-device = { version = "0.15.0", optional = true }
+char-device = { version = "0.16.0", optional = true }
 os_pipe = { version = "1.0.0", features = ["io_safety"], optional = true }
-socketpair = { version = "0.18.0", optional = true }
+socketpair = { version = "0.19.0", optional = true }
 io-lifetimes = { version = "1.0.0", default-features = false }
 ssh2 = { version = "0.9.1", optional = true }
 #socket2 = { version = "0.4.0", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.36.6", features = ["fs", "net"] }
+rustix = { version = "0.37.0", features = ["fs", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 cap-fs-ext = "1.0.0"

--- a/src/fs/file_io_ext.rs
+++ b/src/fs/file_io_ext.rs
@@ -527,7 +527,7 @@ impl<T: AsFilelike + IoExt> FileIoExt for T {
 
     fn append(&self, buf: &[u8]) -> io::Result<usize> {
         use rustix::fs::{fcntl_getfl, fcntl_setfl, seek, OFlags};
-        use rustix::io::write;
+        use rustix::io::{write, SeekFrom};
 
         // On Linux, use `pwritev2`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -554,13 +554,13 @@ impl<T: AsFilelike + IoExt> FileIoExt for T {
         fcntl_setfl(self, old_flags | OFlags::APPEND)?;
         let result = write(self, buf);
         fcntl_setfl(self, old_flags).unwrap();
-        seek(self, std::io::SeekFrom::Start(old_pos)).unwrap();
+        seek(self, SeekFrom::Start(old_pos)).unwrap();
         Ok(result?)
     }
 
     fn append_vectored(&self, bufs: &[IoSlice]) -> io::Result<usize> {
         use rustix::fs::{fcntl_getfl, fcntl_setfl, seek, OFlags};
-        use rustix::io::writev;
+        use rustix::io::{writev, SeekFrom};
 
         // On Linux, use `pwritev2`.
         #[cfg(any(target_os = "android", target_os = "linux"))]
@@ -582,7 +582,7 @@ impl<T: AsFilelike + IoExt> FileIoExt for T {
         fcntl_setfl(self, old_flags | OFlags::APPEND)?;
         let result = writev(self, bufs);
         fcntl_setfl(self, old_flags).unwrap();
-        seek(self, std::io::SeekFrom::Start(old_pos)).unwrap();
+        seek(self, SeekFrom::Start(old_pos)).unwrap();
         Ok(result?)
     }
 


### PR DESCRIPTION
Update to rustix 0.37. The only code change here is to switch from std::io::SeekFrom to rustix::io::SeekFrom.