### PR TITLE
Handle non-files in the the `ReadRead` implementation for `std::fs::File`.

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -3,8 +3,6 @@
 mod fd_flags;
 mod file_io_ext;
 
-use crate::io::IsReadWrite;
-
 pub use fd_flags::{FdFlags, GetSetFdFlags, SetFdFlags};
 pub use file_io_ext::{Advice, FileIoExt};
 
@@ -16,20 +14,3 @@ pub use file_io_ext::{Advice, FileIoExt};
 // TODO: test that remove_dir can remove symlink_dirs, and remove_file files.
 
 // TODO: poll
-
-impl crate::io::ReadReady for std::fs::File {
-    #[inline]
-    fn num_ready_bytes(&self) -> std::io::Result<u64> {
-        let (read, _write) = self.is_read_write()?;
-        if read {
-            let metadata = self.metadata()?;
-            if metadata.is_file() {
-                return Ok(metadata.len());
-            }
-        }
-        Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "stream is not readable",
-        ))
-    }
-}

--- a/tests/read_ready.rs
+++ b/tests/read_ready.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+mod sys_common;
+
+use std::fs::File;
+use std::io::Read;
+use system_interface::io::ReadReady;
+
+#[test]
+fn file_is_read_write() {
+    let mut f = File::open("Cargo.toml").unwrap();
+
+    let len = f.metadata().unwrap().len();
+    assert_eq!(f.num_ready_bytes().unwrap(), len);
+
+    let mut buf = [0u8; 6];
+    f.read_exact(&mut buf).unwrap();
+    assert_eq!(f.num_ready_bytes().unwrap(), len - (buf.len() as u64));
+
+    #[cfg(target_os = "linux")]
+    {
+        let f = File::open("/dev/urandom").unwrap();
+        let _ = f.num_ready_bytes().unwrap();
+
+        let f = File::open("/dev/null").unwrap();
+        let _ = f.num_ready_bytes().unwrap();
+    }
+}


### PR DESCRIPTION
`File` can open special devices like /dev/random or /dev/null; make sure those are handled properly in `ReadReady`.

Also, correctly report the number of ready bytes if the current position is in the middle of a file.