### PR TITLE
Simplify some filesystem extensions on Windows

### DIFF
--- a/tests/vectored_at.rs
+++ b/tests/vectored_at.rs
@@ -412,6 +412,7 @@ fn write_vectored_after_end() {
     let buf1 = b"MNOPQRST".to_vec();
     let bufs = vec![IoSlice::new(&buf0), IoSlice::new(&buf1)];
     let nwritten = check!(file.write_vectored_at(&bufs, 32));
+    assert!(nwritten > 0);
     assert_eq!(check!(file.stream_position()), 26);
     let mut back = String::new();
     check!(file.seek(std::io::SeekFrom::Start(0)));


### PR DESCRIPTION
This commit it borne out of CI failures on bytecodealliance/wasmtime#7638. Investigating this failure has revealed a number of aspects here which I've attempted to address in this PR. The notable changes here are:

* The current code in this crate was handling the case where `FileExt::seek_write` on Windows was leaving intermediate bytes as undefined when a write happened beyond the end of a file. I believe that this is due to an error in the documentation of the Rust standard library which I've submitted rust-lang/rust#120452 to fix.

* Removing handling of "always write zeros" handles the primary failure of the PR bytecodealliance/wasmtime#7638 which is that `write_vectored_at` was always returning 0 on Windows for writes past the end of the file. This is because Windows doesn't have a vectored file write so the vector chosen was the first nonempty vector which was the one containing zeros to extend the file. That meant that the method always returned zero.

* Previously the methods here used file locking which appeared to handle the case where the file was calculated and then the write happened. Given that this no longer happens I've removed the locking here.

* The `write_all_at` method had a loop around `reopen_write` handling the `Interrupted` error but no other methods did, so I opted to remove the loop and leave that to the internals of `reopen_write` if necessary.

* Other methods related to this are all simplified to directly use `seek_write` and avoid handling the case where writes past the end need to write zeros (as zeros are guaranteed by Windows).

Overall my hope is to use this to unblock bytecodealliance/wasmtime#7638 to get more platform-agnostic behavior for writing beyond the end of a file.