### PR TITLE
chore: bump cap-std to 4.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,8 +136,7 @@ jobs:
     # test it on nightly which has the new name.
     - run: cargo check --workspace --bins --examples --tests --features=cap_std_impls --release -vv --target=x86_64-unknown-fuchsia
 
-    # socket2, cap_async_std_impls, and cap_async_std_impls_fs_utf8 temporarily
-    # disabled until I/O safety trait impls are available
+    # socket2 temporarily disabled until I/O safety trait impls are available
     - run: cargo check --workspace --all-targets --all-features --release -vv
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-linux-musl
     - run: cargo check --workspace --all-targets --features=cap_std_impls,cap_std_impls_fs_utf8,char-device,use_os_pipe,socketpair --release -vv --target=x86_64-unknown-linux-gnux32

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,8 @@ edition = "2021"
 exclude = ["/.github"]
 
 [dependencies]
-async-std = { version = "1.13.0", optional = true, features = ["io_safety"] }
 bitflags = "2.2.3"
-cap-std = { version = "3.0.0", optional = true }
-cap-async-std = { version = "3.0.0", optional = true }
+cap-std = { version = "4.0.0", optional = true }
 char-device = { version = "0.16.0", optional = true }
 os_pipe = { version = "1.0.0", features = ["io_safety"], optional = true }
 socketpair = { version = "0.19.0", optional = true }
@@ -26,8 +24,8 @@ ssh2 = { version = "0.9.1", optional = true }
 rustix = { version = "0.38.0", features = ["fs", "net"] }
 
 [target.'cfg(windows)'.dependencies]
-cap-std = "3.0.0"
-cap-fs-ext = "3.0.0"
+cap-std = "4.0.0"
+cap-fs-ext = "4.0.0"
 winx = "0.36.0"
 fd-lock = "4.0.0"
 
@@ -41,17 +39,15 @@ features = [
 ]
 
 [dev-dependencies]
-cap-fs-ext = "3.0.0"
-cap-tempfile = "3.0.0"
-cap-std = "3.0.0"
+cap-fs-ext = "4.0.0"
+cap-tempfile = "4.0.0"
+cap-std = "4.0.0"
 tempfile = "3.2.0"
 
 [features]
 default = []
 cap_std_impls = ["cap-std"]
-cap_async_std_impls = ["async-std", "cap-async-std", "io-lifetimes/async-std"]
 cap_std_impls_fs_utf8 = ["cap-std/fs_utf8"]
-cap_async_std_impls_fs_utf8 = ["async-std", "cap-async-std/fs_utf8"]
 use_os_pipe = ["os_pipe", "io-lifetimes/os_pipe"]
 #use_socket2 = ["socket2", "io-lifetimes/socket2"]
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ used with regular [`std`] too. To separate concerns, all sandboxing and
 capability-oriented APIs are left to `cap-std`, so this crate's features are
 usable independently.
 
-Support for async-std and socket2 is temporarily disabled until those crates
-contain the needed implementations of the I/O safety traits.
+Support for socket2 is temporarily disabled until it contains the needed
+implementations of the I/O safety traits.
 
 [`std`]: https://doc.rust-lang.org/std/
 [`cap-std`]: https://crates.io/crates/cap-std

--- a/src/io/is_read_write.rs
+++ b/src/io/is_read_write.rs
@@ -52,37 +52,6 @@ impl IsReadWrite for cap_std::fs_utf8::File {
     }
 }
 
-#[cfg(all(windows, feature = "async-std"))]
-impl IsReadWrite for async_std::fs::File {
-    #[inline]
-    fn is_read_write(&self) -> io::Result<(bool, bool)> {
-        use io_lifetimes::AsFilelike;
-        file_is_read_write(&self.as_filelike_view::<std::fs::File>())
-    }
-}
-
-#[cfg(all(windows, feature = "async-std"))]
-impl IsReadWrite for cap_async_std::fs::File {
-    #[inline]
-    fn is_read_write(&self) -> io::Result<(bool, bool)> {
-        use io_lifetimes::AsFilelike;
-        file_is_read_write(&self.as_filelike_view::<std::fs::File>())
-    }
-}
-
-#[cfg(all(
-    windows,
-    feature = "async-std",
-    feature = "cap_async_std_impls_fs_utf8"
-))]
-impl IsReadWrite for cap_async_std::fs_utf8::File {
-    #[inline]
-    fn is_read_write(&self) -> io::Result<(bool, bool)> {
-        use io_lifetimes::AsFilelike;
-        file_is_read_write(&self.as_filelike_view::<std::fs::File>())
-    }
-}
-
 #[cfg(windows)]
 impl IsReadWrite for std::net::TcpStream {
     #[inline]
@@ -93,22 +62,6 @@ impl IsReadWrite for std::net::TcpStream {
 
 #[cfg(all(windows, feature = "cap_std_impls"))]
 impl IsReadWrite for cap_std::net::TcpStream {
-    #[inline]
-    fn is_read_write(&self) -> io::Result<(bool, bool)> {
-        raw_socket_is_read_write(self.as_raw_socket())
-    }
-}
-
-#[cfg(all(windows, feature = "cap_async_std_impls"))]
-impl IsReadWrite for async_std::net::TcpStream {
-    #[inline]
-    fn is_read_write(&self) -> io::Result<(bool, bool)> {
-        raw_socket_is_read_write(self.as_raw_socket())
-    }
-}
-
-#[cfg(all(windows, feature = "cap_async_std_impls"))]
-impl IsReadWrite for cap_async_std::net::TcpStream {
     #[inline]
     fn is_read_write(&self) -> io::Result<(bool, bool)> {
         raw_socket_is_read_write(self.as_raw_socket())


### PR DESCRIPTION
This removes the async-std related features since they were removed from
cap-std.
