### PR TITLE
ci: fix various issues with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows, macos, macos-14, beta, ubuntu-20.04, windows-2019, aarch64-ubuntu]
+        build: [stable, windows, macos, macos-14, beta, ubuntu-22.04, windows-2019, aarch64-ubuntu]
         include:
           - build: stable
             os: ubuntu-latest
@@ -180,8 +180,8 @@ jobs:
           - build: beta
             os: ubuntu-latest
             rust: beta
-          - build: ubuntu-20.04
-            os: ubuntu-20.04
+          - build: ubuntu-22.04
+            os: ubuntu-22.04
             rust: stable
           - build: windows-2019
             os: windows-2019

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,7 @@ jobs:
       run: |
         set -ex
         sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build
+        sudo apt-get install -y ${{ matrix.gcc_package }} ninja-build libglib2.0-dev
 
         # Download and build qemu from source since the most recent release is
         # way faster at arm emulation than the current version github actions'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows, macos, macos-13, beta, ubuntu-20.04, windows-2019, aarch64-ubuntu]
+        build: [stable, windows, macos, macos-14, beta, ubuntu-20.04, windows-2019, aarch64-ubuntu]
         include:
           - build: stable
             os: ubuntu-latest
@@ -174,8 +174,8 @@ jobs:
           - build: macos
             os: macos-latest
             rust: stable
-          - build: macos-13
-            os: macos-13
+          - build: macos-14
+            os: macos-14
             rust: stable
           - build: beta
             os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, windows, macos, macos-14, beta, ubuntu-22.04, windows-2019, aarch64-ubuntu]
+        build: [stable, windows, macos, macos-14, beta, ubuntu-22.04, windows-2022, aarch64-ubuntu]
         include:
           - build: stable
             os: ubuntu-latest
@@ -183,8 +183,8 @@ jobs:
           - build: ubuntu-22.04
             os: ubuntu-22.04
             rust: stable
-          - build: windows-2019
-            os: windows-2019
+          - build: windows-2022
+            os: windows-2022
             rust: stable
           - build: aarch64-ubuntu
             os: ubuntu-latest


### PR DESCRIPTION
The aarch64-ubuntu CI job builds QEMU 6.1.0 from source, but its
configure step requires glib-2.56/gthread-2.0. The apt-get install was
missing libglib2.0-dev, causing the build to fail with:

  ERROR: glib-2.56 gthread-2.0 is required to compile QEMU

---

I subsequently found a few other issues in CI:

- macos-13 runners are no longer supported so this updates to macos-14
- ubuntu-20.04 is no longer supported so this updates to ubuntu-22.04
- windows-2019 is no longer supported so this updates to windows-2022


